### PR TITLE
Fixed loading of Fastlane::Actions::VerifyBuildAction

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -8,7 +8,8 @@ require 'xcode/install/command'
 require 'xcode/install/version'
 require 'shellwords'
 require 'open3'
-require 'fastlane/actions/actions_helper'
+require 'fastlane/action'
+require 'fastlane/actions/verify_build'
 
 module XcodeInstall
   CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")


### PR DESCRIPTION
requiring 'fastlane/actions/actions_helper' doesn't load actions automatically.

we need to call `Fastlane::Actions.load_default_actions` to load all actions. But that requires `fastlane/action`.

instead of loading all actions, I decided to just load `verify_build`. Loading `verify_build` also requires `fastlane/action`, hence we are loading `fastlane/action` first, and then `fastlane/action/verify_build`