### PR TITLE
pass string to gather_cert_info

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -688,7 +688,7 @@ HELP
     end
 
     def verify_app_cert
-      cert_info = Fastlane::Actions::VerifyBuildAction.gather_cert_info(@path)
+      cert_info = Fastlane::Actions::VerifyBuildAction.gather_cert_info(@path.to_s)
       apple_team_identifier_result = cert_info['team_identifier'] == TEAM_IDENTIFIER
       apple_authority_result = cert_info['authority'].include?(AUTHORITY)
       apple_team_identifier_result && apple_authority_result


### PR DESCRIPTION
Fastlane adds `shellescape` to `String` class, and calls this function whenever passing string to shell command.

`@path` in `install.rb` is object of `Pathname` so when `VerifyBuildAction.gather_cert_info` calls `shellescape` on it, it fails.

this conversion to string should fix it